### PR TITLE
White space before select statement breaks query. 

### DIFF
--- a/src/pagination.php
+++ b/src/pagination.php
@@ -306,7 +306,7 @@ class pagination
          */
         if(substr($this->query, 0, 26) != 'SELECT SQL_CALC_FOUND_ROWS')
         {
-            $this->query = substr_replace($this->query, 'SELECT SQL_CALC_FOUND_ROWS', 0, 6);
+            $this->query = substr_replace(trim($this->query), 'SELECT SQL_CALC_FOUND_ROWS', 0, 6);
         }
         
         /*


### PR DESCRIPTION
If a query has any whitespace before SELECT, the substr_replace call in prepare_query fails. 

``` php
$this->query = substr_replace($this->query, 'SELECT SQL_CALC_FOUND_ROWS', 0, 6);
```

I often write sql statements like below 

``` php
$query = "
    SELECT
      sg.spaceID,
      ( :earthRadius ...
```

A trim solves
